### PR TITLE
Enable View Binding

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,6 +7,9 @@ plugins {
 android {
     compileSdk 30
     buildToolsVersion "30.0.3"
+    buildFeatures{
+        viewBinding true
+    }
 
     defaultConfig {
         applicationId "com.draco.buoy"

--- a/app/src/main/java/com/draco/buoy/views/MainActivity.kt
+++ b/app/src/main/java/com/draco/buoy/views/MainActivity.kt
@@ -5,17 +5,20 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.FragmentContainerView
 import com.draco.buoy.R
+import com.draco.buoy.databinding.ActivityMainBinding
 import com.draco.buoy.fragments.MainPreferenceFragment
 import com.draco.buoy.utils.PermissionUtils
 
 class MainActivity : AppCompatActivity() {
     private lateinit var preferences: FragmentContainerView
-
+    private lateinit var binding: ActivityMainBinding;
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        // inflate the layout and set content view to root
+        binding = ActivityMainBinding.inflate(layoutInflater);
+        setContentView(binding.root)
 
-        preferences = findViewById(R.id.preferences)
+        preferences = binding.preferences;
 
         /* If we are missing a permission, lock the user in the permission activity */
         if (!PermissionUtils.isPermissionsGranted(this, android.Manifest.permission.WRITE_SECURE_SETTINGS))

--- a/app/src/main/java/com/draco/buoy/views/PermissionActivity.kt
+++ b/app/src/main/java/com/draco/buoy/views/PermissionActivity.kt
@@ -8,27 +8,26 @@ import android.widget.TextView
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.draco.buoy.R
+import com.draco.buoy.databinding.ActivityPermissionBinding
 import com.draco.buoy.viewmodels.PermissionActivityViewModel
 import com.google.android.material.snackbar.Snackbar
 
 class PermissionActivity : AppCompatActivity() {
     private val viewModel: PermissionActivityViewModel by viewModels()
 
-    private lateinit var command: TextView
-
+    private lateinit var binding: ActivityPermissionBinding;
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_permission)
-
-        command = findViewById(R.id.command)
+        binding = ActivityPermissionBinding.inflate(layoutInflater);
+        setContentView(binding.root)
 
         /* Copy ADB command to clipboard */
-        command.setOnClickListener {
+        binding.command.setOnClickListener {
             val clipboardManager = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-            val clip = ClipData.newPlainText("ADB Command", command.text.toString())
+            val clip = ClipData.newPlainText("ADB Command", binding.command.text.toString())
             clipboardManager.setPrimaryClip(clip)
 
-            Snackbar.make(command, R.string.copied, Snackbar.LENGTH_SHORT).show()
+            Snackbar.make(binding.command, R.string.copied, Snackbar.LENGTH_SHORT).show()
         }
 
         /* Once permission is granted, return */


### PR DESCRIPTION
view binding is a type-safe way to interact with your layout from view. Every XML created gets a generated Binding class which you can use to access the ui components.
this is usually preferred over findViewById as it is type-safe and makes your code look cleaner, especially if you have a lot of components, you can avoid having tons of global variables.

please see https://developer.android.com/topic/libraries/view-binding